### PR TITLE
arm builds, v1 recipe

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -48,6 +48,46 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         store_build_artifacts: false
+      osx_arm64_mpimpichpython3.10.____cpython:
+        CONFIG: osx_arm64_mpimpichpython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_mpimpichpython3.11.____cpython:
+        CONFIG: osx_arm64_mpimpichpython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_mpimpichpython3.12.____cpython:
+        CONFIG: osx_arm64_mpimpichpython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_mpimpichpython3.13.____cp313:
+        CONFIG: osx_arm64_mpimpichpython3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_mpiopenmpipython3.10.____cpython:
+        CONFIG: osx_arm64_mpiopenmpipython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_mpiopenmpipython3.11.____cpython:
+        CONFIG: osx_arm64_mpiopenmpipython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_mpiopenmpipython3.12.____cpython:
+        CONFIG: osx_arm64_mpiopenmpipython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
+      osx_arm64_mpiopenmpipython3.13.____cp313:
+        CONFIG: osx_arm64_mpiopenmpipython3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.10.____cpython.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.11.____cpython.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.12.____cpython.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.13.____cp313.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.10.____cpython.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.11.____cpython.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.12.____cpython.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.13.____cp313.yaml
@@ -1,0 +1,37 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.10.____cpython.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.11.____cpython.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.12.____cpython.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.13.____cp313.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.10.____cpython.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.11.____cpython.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.12.____cpython.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.13.____cp313.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '5'
+numpy:
+- '2'
+openmpi:
+- '5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -70,6 +70,54 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_mpimpichpython3.10.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_mpimpichpython3.11.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_mpimpichpython3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_mpimpichpython3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_mpiopenmpipython3.10.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_mpiopenmpipython3.11.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_mpiopenmpipython3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_mpiopenmpipython3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
     steps:
 
     - name: Checkout code

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -58,20 +58,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+  pip rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"
@@ -89,29 +89,21 @@ source run_conda_forge_build_setup
 
 ( endgroup "Configuring conda" ) 2> /dev/null
 
-echo -e "\n\nMaking the build clobber file"
-make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build does not currently support debug mode"
 else
 
-    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
-        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+    rattler-build build --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="$flow_run_id" \
+        --extra-meta remote_url="$remote_url" \
+        --extra-meta sha="$sha"
 
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ Summary: LFPy is a Python-module for calculation of extracellular potentials fro
 
 Development: https://github.com/LFPy/LFPy
 
-Documentation: https://lfpy.readthedocs.io
+Documentation: https://lfpy.readthedocs.io/
 
 LFPy provides a set of easy-to-use Python classes for setting up your
 model, running your simulations and calculating the extracellular
 potentials arising from activity in your model neuron. If you have a model
 working in NEURON or NeuroML2 already, it is likely that it can be adapted
 to work with LFPy.
-
 
 Current build status
 ====================

--- a/README.md
+++ b/README.md
@@ -94,6 +94,62 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpichpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpichpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpimpichpython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpichpython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpipython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpipython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpipython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpipython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_mpimpichpython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
@@ -147,6 +203,62 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpipython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpichpython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpichpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpichpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpichpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpichpython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpichpython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpipython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpipython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpipython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6817&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lfpy-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpipython3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,6 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+provider:
+  linux_aarch64: default
+  osx_arm64: default

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,6 +4,7 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+conda_build_tool: rattler-build
 provider:
   linux_aarch64: default
   osx_arm64: default

--- a/recipe/483.patch
+++ b/recipe/483.patch
@@ -1,0 +1,87 @@
+From aef2812b2d7a46a5238082460a0b4aa4c35e8da1 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Wed, 13 May 2026 11:02:56 -0700
+Subject: [PATCH] fix building cython extension with pip install
+
+poetry backend invokes as a plain script, not build(setup_kwargs)
+---
+ build.py       | 29 +++++++++++++++++++++++------
+ pyproject.toml |  3 ++-
+ 2 files changed, 25 insertions(+), 7 deletions(-)
+
+diff --git a/build.py b/build.py
+index 18005099..7a0175c9 100644
+--- a/build.py
++++ b/build.py
+@@ -1,16 +1,19 @@
+ """Build script for Cython extensions, used by poetry's build system."""
+ 
+ import os
++import shutil
++from pathlib import Path
+ 
+ 
+-def build(setup_kwargs):
++def main():
+     """Build Cython extensions when invoked by poetry."""
+     try:
+         import numpy as np
+         from Cython.Build import cythonize
+         from Cython.Distutils import build_ext
+-        from setuptools import Extension
+-
++        from setuptools import Distribution, Extension
++        
++        print("Building Cython extensions")
+         ext_modules = [
+             Extension(
+                 'LFPy.run_simulation',
+@@ -23,10 +26,24 @@ def build(setup_kwargs):
+                 include_dirs=[np.get_include()],
+             ),
+         ]
+-        setup_kwargs.update({
+-            'ext_modules': cythonize(ext_modules),
+-            'cmdclass': {'build_ext': build_ext},
++        distribution = Distribution({
++            "name": "LFPy",
++            "ext_modules": cythonize(ext_modules),
+         })
++
++        cmd = build_ext(distribution)
++        cmd.ensure_finalized()
++        cmd.run()
++
++        for output in cmd.get_outputs():
++            output = Path(output)
++            relative_extension = output.relative_to(cmd.build_lib)
++            print(f"Copying {output} -> {relative_extension}")
++            shutil.copyfile(output, relative_extension)
+     except ImportError:
+         print("'Cython' or 'numpy' not found – Cython extensions will not be "
+               "compiled and simulations in LFPy may run slower.")
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/pyproject.toml b/pyproject.toml
+index 22adcc9e..4e45e205 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -18,6 +18,7 @@ include = [
+     "LFPy/test/*.py",
+     "LFPy/test/sinsyn.mod",
+     "LFPy/test/expsyni.mod",
++    { path = "LFPy/**/*.so", format = "wheel" }
+ ]
+ classifiers = [
+     "License :: OSI Approved :: GNU General Public License (GPL)",
+@@ -40,7 +41,7 @@ classifiers = [
+ 
+ [tool.poetry.build]
+ script = "build.py"
+-generate-setup-file = true
++generate-setup-file = false
+ 
+ [tool.poetry.dependencies]
+ python = "^3.10"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -56,7 +56,8 @@ tests:
   - python:
       imports:
         - LFPy
-      # lfpy expresses its pip dependencies incorrectly
+      # pip check fails because of neuron not installing
+      # correct metadata
       pip_check: false
   - requirements:
       run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,34 +1,43 @@
-{% set name = "LFPy" %}
-{% set version = "2.3.7" %}
-{% set build = 1 %}
+schema_version: 1
+
+context:
+  name: LFPy
+  version: "2.3.7"
+  build: 2
 
 package:
-  name: {{ name | lower }}
-  version: {{ version }}
+  name: ${{ name | lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/l/lfpy/lfpy-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/l/lfpy/lfpy-${{ version }}.tar.gz
   sha256: eb7c5ab05bcd96c93566f8302bbd15fc5e11eeecd17be21f7b93342c0772015d
+  patches:
+    - 483.patch
 
 build:
-  number: {{ build }}
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [win]
+  number: ${{ build }}
+  skip: win
+  script: ${{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  files:
+    exclude:
+      # avoid installing cython .c files
+      - "**/LFPy/*.c"
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ stdlib("c") }}
-    - {{ compiler('cxx') }}
-    - make  # [linux]
+    - ${{ compiler('c') }}
+    - ${{ stdlib("c") }}
+    - ${{ compiler('cxx') }}
   host:
     - python
     - pip
     - cython >=0.20
     - poetry-core
+    - poetry
     - numpy
     - neuron
-    - {{ mpi }}
+    - ${{ mpi }}
     - lfpykit >=0.6.2
   run:
     - python
@@ -38,30 +47,30 @@ requirements:
     - numpy
     - h5py >=2.5
     - mpi4py >=1.2
-    - {{ mpi }}
-    - {{ pin_compatible('neuron') }}
+    - ${{ mpi }}
     - lfpykit >=0.6.2
     - ncurses
     - readline
 
-test:
-  requires:
-    - openssh  # [mpi == "openmpi"]
-    - pytest
-    - make  # [linux]
-    - {{ compiler('cxx') }}
-  imports:
-    - LFPy
-  commands:
-    - pytest -vsx --pyargs LFPy
+tests:
+  - python:
+      imports:
+        - LFPy
+      # lfpy expresses its pip dependencies incorrectly
+      pip_check: false
+  - requirements:
+      run:
+        - pytest
+        - if: linux
+          then: make
+        - ${{ compiler('cxx') }}
+    script:
+      - pytest -vsx --pyargs LFPy
 
 about:
-  home: https://github.com/LFPy/LFPy
   license: GPL-3.0-only
-  license_family: GPL
   license_file: LICENSE
   summary: LFPy is a Python-module for calculation of extracellular potentials from multicompartment neuron models
-
   description: |
     LFPy provides a set of easy-to-use Python classes for setting up your
     model, running your simulations and calculating the extracellular
@@ -69,8 +78,9 @@ about:
     working in NEURON or NeuroML2 already, it is likely that it can be adapted
     to work with LFPy.
 
-  doc_url: https://lfpy.readthedocs.io
-  dev_url: https://github.com/LFPy/LFPy
+  homepage: https://github.com/LFPy/LFPy
+  repository: https://github.com/LFPy/LFPy
+  documentation: https://lfpy.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
closes #43
closes #23


includes backport of https://github.com/LFPy/LFPy/pull/483 to fix the cython builds, which get skipped in 2.3.7